### PR TITLE
Fixed pagination parameters.

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,11 +77,20 @@ try {
     // Lazy fetcher
     $ordersPage1 = $pager->fetch($orderApiClient, 'all');
     if (true === $pager->hasNext()) {
-     $ordersPage2 = $pager->fetchNext();
+        $ordersPage2 = $pager->fetchNext();
     }
 
-    // Eager fetcher
+    // Eager fetcher (Very slow !!! prefer lazy fetcher)
     $orders = $pager->fetchAll($orderApiClient, 'all');
+    
+    // Parameters
+    $orderApiClient->setPerPage('5');
+    $orders = $pager->fetch($orderApiClient, 'all');
+    
+    OR
+    
+    $orders = $pager->fetch($orderApiClient, 'all', array('perPage' => 5, 'page' => 2);
+    
 } catch (\Exception $e) {
     // error logging ?
 }

--- a/src/Meup/Api/Client/Api/AbstractApi.php
+++ b/src/Meup/Api/Client/Api/AbstractApi.php
@@ -77,8 +77,8 @@ abstract class AbstractApi implements ApiInterface
      */
     protected function get($path, array $parameters = array(), $requestHeaders = array())
     {
-        if (null !== $this->perPage && !isset($parameters['per_page'])) {
-            $parameters['per_page'] = $this->perPage;
+        if (null !== $this->perPage && !isset($parameters['perPage'])) {
+            $parameters['perPage'] = $this->perPage;
         }
         if (array_key_exists('ref', $parameters) && is_null($parameters['ref'])) {
             unset($parameters['ref']);

--- a/src/Meup/Api/Client/Api/Order.php
+++ b/src/Meup/Api/Client/Api/Order.php
@@ -10,6 +10,8 @@
 
 namespace Meup\Api\Client\Api;
 
+use Meup\Api\Client\Utils\HttpRequestParametersBuilder;
+
 /**
  * Order API
  *
@@ -38,10 +40,12 @@ class Order extends AbstractApi
      *
      * @link http://developers.1001pharmacies.com/docs/v1/orders.html#tocAnchor-1-3-1
      *
-     * @return null|array orders found
+     * @param array $parameters
+     *
+     * @return array|null orders found
      */
-    public function all()
+    public function all($parameters = array())
     {
-        return $this->get('api/orders');
+        return $this->get('api/orders' . HttpRequestParametersBuilder::buildFromArray($parameters));
     }
 }

--- a/src/Meup/Api/Client/HttpClient/HttpClient.php
+++ b/src/Meup/Api/Client/HttpClient/HttpClient.php
@@ -250,7 +250,7 @@ class HttpClient implements HttpClientInterface
     ) {
         return $this->client->createRequest(
             $httpMethod,
-            rtrim($this->options['base_url'], '/') . '/' . $path,
+            rtrim($this->options['base_url'], '/') . '/' . ltrim($path, '/'),
             array_merge($this->headers, $headers),
             $body,
             $options

--- a/src/Meup/Api/Client/ResultPager.php
+++ b/src/Meup/Api/Client/ResultPager.php
@@ -65,7 +65,7 @@ class ResultPager implements ResultPagerInterface
      */
     public function fetch(ApiInterface $api, $method, array $parameters = array())
     {
-        $result = call_user_func_array(array($api, $method), $parameters);
+        $result = call_user_func_array(array($api, $method), array($parameters));
         $this->postFetch();
 
         return $result;
@@ -76,7 +76,7 @@ class ResultPager implements ResultPagerInterface
      */
     public function fetchAll(ApiInterface $api, $method, array $parameters = array())
     {
-        $result = call_user_func_array(array($api, $method), $parameters);
+        $result = call_user_func_array(array($api, $method), array($parameters));
         $this->postFetch();
 
         $finalResult = $result['_embedded']['items'];

--- a/src/Meup/Api/Client/Utils/HttpRequestParametersBuilder.php
+++ b/src/Meup/Api/Client/Utils/HttpRequestParametersBuilder.php
@@ -15,7 +15,7 @@ class HttpRequestParametersBuilder
     public static function buildFromArray($parameters = array())
     {
         $queryString = "";
-        if ($parameters) {
+        if ($parameters && is_array($parameters)) {
             $queryString .= "?";
             foreach ($parameters as $param => $value) {
                 $queryString .= $param . "=" . $value . "&";

--- a/src/Meup/Api/Client/Utils/HttpRequestParametersBuilder.php
+++ b/src/Meup/Api/Client/Utils/HttpRequestParametersBuilder.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * This file is part of the Sherlock Project
+ *
+ * (c) 1001pharmacies <http://github.com/1001pharmacies/sherlock>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Meup\Api\Client\Utils;
+
+class HttpRequestParametersBuilder
+{
+    public static function buildFromArray($parameters = array())
+    {
+        $queryString = "";
+        if ($parameters) {
+            $queryString .= "?";
+            foreach ($parameters as $param => $value) {
+                $queryString .= $param . "=" . $value . "&";
+            }
+            $queryString = rtrim($queryString, "&");
+        }
+        return $queryString;
+    }
+}


### PR DESCRIPTION
fixed parameter 'per_page' > 'perPage'.

```php
    $orderApiClient->setPerPage('5');
    $orders = $pager->fetch($orderApiClient, 'all');
```

you can now push query parameters to fetch() method.

```php
$orders = $pager->fetch($orderApiClient, 'all', array('perPage' => 5, 'page' => 2);
```